### PR TITLE
fix: add registry-url to setup-node for npm OIDC token exchange

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "24"
+          registry-url: https://registry.npmjs.org
       - name: Download build artifacts
         uses: actions/download-artifact@v5
         with:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -87,6 +87,8 @@ releaseWorkflow.file!.addOverride('jobs.release_npm.permissions.id-token', 'writ
 releaseWorkflow.file!.addOverride('jobs.release_npm.permissions.contents', 'write');
 // Override node-version to 24 for npm trusted publishing (requires npm 11.5.1+)
 releaseWorkflow.file!.addOverride('jobs.release_npm.steps.0.with.node-version', '24');
+// Set registry-url so setup-node configures .npmrc for OIDC token exchange
+releaseWorkflow.file!.addOverride('jobs.release_npm.steps.0.with.registry-url', 'https://registry.npmjs.org');
 // Add --ignore-engines to yarn install since Node 24 is outside the engines range (20.x)
 releaseWorkflow.file!.addOverride('jobs.release_npm.steps.4.run',
   'cd .repo && yarn install --check-files --frozen-lockfile --ignore-engines');


### PR DESCRIPTION
## Summary
- Add `registry-url: https://registry.npmjs.org` to the `setup-node` step in the `release_npm` job
- Required for `actions/setup-node` to configure `.npmrc` with OIDC token for npm trusted publishing

## Context
The release workflow was failing with `ENEEDAUTH` because npm wasn't receiving the OIDC token. The `setup-node` action needs `registry-url` to set up authentication.