### PR TITLE
feat: report non-importable drifted resources

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { Ora } from 'ora';
 import { CfnClientWrapper } from './lib/cfn-client';
 import { isResourceImportable, getAllRequiredCapabilities } from './lib/eligible-resources';
-import { displayCascadeWarning, promptForDecisions } from './lib/interactive';
+import { displayCascadeWarning, displayNonImportableReport, promptForDecisions } from './lib/interactive';
 import { buildPlan, serializePlan, loadPlan, planToDecisions } from './lib/plan';
 import { buildResourcesToImport, buildReimportDescriptor } from './lib/resource-importer';
 import {
@@ -54,6 +54,7 @@ export async function remediate(
     remediatedResources: [],
     skippedResources: [],
     removedResources: [],
+    nonImportableResources: [],
     errors: [],
   };
 
@@ -123,28 +124,65 @@ export async function remediate(
         return result;
       }
 
-      // Filter to only importable resources
+      // Categorize drifted resources by importability and drift status
       const modifiedResources: DriftedResource[] = [];
       const deletedResources: DriftedResource[] = [];
+      const nonImportableModified: DriftedResource[] = [];
+      const nonImportableDeleted: DriftedResource[] = [];
 
       for (const resource of allDriftedResources) {
-        if (!isResourceImportable(resource.resourceType)) {
-          result.skippedResources.push(resource.logicalResourceId);
-          continue;
-        }
+        const importable = isResourceImportable(resource.resourceType);
         if (resource.stackResourceDriftStatus === 'DELETED') {
-          deletedResources.push(resource);
+          if (importable) {
+            deletedResources.push(resource);
+          } else {
+            nonImportableDeleted.push(resource);
+          }
         } else {
-          modifiedResources.push(resource);
+          if (importable) {
+            modifiedResources.push(resource);
+          } else {
+            nonImportableModified.push(resource);
+          }
         }
       }
 
-      if (modifiedResources.length === 0 && deletedResources.length === 0) {
+      // Track non-importable resources in result
+      for (const r of nonImportableModified) {
+        result.nonImportableResources.push({
+          logicalResourceId: r.logicalResourceId,
+          resourceType: r.resourceType,
+          physicalResourceId: r.physicalResourceId,
+          driftStatus: 'MODIFIED',
+          propertyDifferences: r.propertyDifferences,
+        });
+      }
+      for (const r of nonImportableDeleted) {
+        result.nonImportableResources.push({
+          logicalResourceId: r.logicalResourceId,
+          resourceType: r.resourceType,
+          physicalResourceId: r.physicalResourceId,
+          driftStatus: 'DELETED',
+        });
+      }
+
+      // Display non-importable report before prompts
+      if (nonImportableModified.length > 0 || nonImportableDeleted.length > 0) {
+        if (spinner) spinner.stop();
+        displayNonImportableReport(nonImportableModified, nonImportableDeleted);
+      }
+
+      // If all drifted resources are non-importable MODIFIED, report and return
+      if (modifiedResources.length === 0 && deletedResources.length === 0 && nonImportableDeleted.length === 0) {
+        if (nonImportableModified.length > 0) {
+          result.success = true;
+          return result;
+        }
         result.errors.push('All drifted resources are not eligible for import');
         return result;
       }
 
-      // Step 4: Interactive decisions
+      // Step 4: Interactive decisions (importable resources only)
       if (spinner) spinner.stop();
 
       decisions = await promptForDecisions(
@@ -152,6 +190,11 @@ export async function remediate(
         deletedResources,
         options.yes ?? false,
       );
+
+      // Non-importable DELETED resources are always removed (no prompt needed)
+      for (const r of nonImportableDeleted) {
+        decisions.remove.push(r);
+      }
 
       if (spinner) spinner.start('Processing...');
 
@@ -164,7 +207,7 @@ export async function remediate(
           toolVersion: packageVersion(),
           driftDetectionId: detectionId,
         };
-        const plan = buildPlan(planMetadata, decisions);
+        const plan = buildPlan(planMetadata, decisions, nonImportableModified);
         const planPath = path.resolve(options.exportPlan);
         fs.writeFileSync(planPath, serializePlan(plan));
         if (spinner) spinner.succeed(`Plan exported to ${planPath}`);
@@ -269,6 +312,13 @@ export async function remediate(
         console.log('\nResources temporarily removed and recreated:');
         for (const c of temporaryCascade) {
           console.log(`  - ${c.logicalResourceId} (${c.resourceType}) -> depends on ${c.dependsOn}`);
+        }
+      }
+      const reportOnly = result.nonImportableResources.filter((r) => r.driftStatus === 'MODIFIED');
+      if (reportOnly.length > 0) {
+        console.log('\nNon-importable drifted resources (manual action required):');
+        for (const r of reportOnly) {
+          console.log(`  - ${r.logicalResourceId} (${r.resourceType}) [MODIFIED]`);
         }
       }
       result.success = true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,15 @@ program
             console.log(chalk.yellow(`  - ${resource}`));
           }
         }
+
+        const reportOnly = result.nonImportableResources?.filter((r) => r.driftStatus === 'MODIFIED') ?? [];
+        if (reportOnly.length > 0) {
+          console.log(chalk.yellow('\nNon-importable drifted resources (manual action required):'));
+          for (const r of reportOnly) {
+            console.log(chalk.yellow(`  - ${r.logicalResourceId} (${r.resourceType})`));
+          }
+          console.log(chalk.dim('  Update your CDK/CloudFormation source to match, or revert manually.'));
+        }
       } else {
         spinner.fail(chalk.red('Drift remediation failed'));
         for (const error of result.errors) {
@@ -111,5 +120,5 @@ export * from './lib/eligible-resources';
 export * from './lib/template-transformer';
 export * from './lib/resource-importer';
 export * from './lib/resource-identifier';
-export { promptForDecisions, formatDriftDiff, displayCascadeWarning } from './lib/interactive';
+export { promptForDecisions, formatDriftDiff, displayCascadeWarning, displayNonImportableReport } from './lib/interactive';
 export { buildPlan, serializePlan, loadPlan, planToDecisions } from './lib/plan';

--- a/src/lib/interactive.ts
+++ b/src/lib/interactive.ts
@@ -201,6 +201,56 @@ export function displayCascadeWarning(
 }
 
 /**
+ * Display a report of non-importable drifted resources.
+ * Called before interactive prompts so the user has the full picture.
+ */
+export function displayNonImportableReport(
+  modifiedNonImportable: DriftedResource[],
+  deletedNonImportable: DriftedResource[],
+): void {
+  if (modifiedNonImportable.length === 0 && deletedNonImportable.length === 0) return;
+
+  const total = modifiedNonImportable.length + deletedNonImportable.length;
+  console.log(chalk.bold.yellow(
+    `\n${total} drifted resource(s) cannot be auto-remediated (not importable by CloudFormation):`,
+  ));
+
+  if (modifiedNonImportable.length > 0) {
+    console.log(chalk.bold.yellow(
+      `\n  MODIFIED (report only - ${modifiedNonImportable.length}):`,
+    ));
+    for (const r of modifiedNonImportable) {
+      console.log(chalk.yellow(
+        `    ${r.logicalResourceId} (${r.resourceType})`,
+      ));
+      console.log(chalk.dim(`      Physical ID: ${r.physicalResourceId}`));
+      if (r.propertyDifferences && r.propertyDifferences.length > 0) {
+        console.log(chalk.dim('      Changes:'));
+        console.log(formatDriftDiff(r.propertyDifferences));
+      }
+    }
+    console.log(chalk.dim(
+      '\n  To fix: update your CDK/CloudFormation source to match the actual state, or revert the resource manually.\n',
+    ));
+  }
+
+  if (deletedNonImportable.length > 0) {
+    console.log(chalk.bold.red(
+      `\n  DELETED (will be removed from template - ${deletedNonImportable.length}):`,
+    ));
+    for (const r of deletedNonImportable) {
+      console.log(chalk.red(
+        `    ${r.logicalResourceId} (${r.resourceType})`,
+      ));
+      console.log(chalk.dim(`      Former Physical ID: ${r.physicalResourceId}`));
+    }
+    console.log(chalk.dim(
+      '\n  These resources no longer exist in AWS and will be removed from the stack template.\n',
+    ));
+  }
+}
+
+/**
  * Run the full interactive prompt flow for all drifted resources.
  * When `autoAccept` is true, returns default actions without prompting.
  */

--- a/src/lib/plan.ts
+++ b/src/lib/plan.ts
@@ -6,7 +6,7 @@ import {
   RemediationPlan,
 } from './types';
 
-const VALID_ACTIONS = new Set(['autofix', 'reimport', 'remove', 'skip']);
+const VALID_ACTIONS = new Set(['autofix', 'reimport', 'remove', 'skip', 'report_only']);
 
 /**
  * Build a RemediationPlan from drift detection results and interactive decisions.
@@ -14,6 +14,7 @@ const VALID_ACTIONS = new Set(['autofix', 'reimport', 'remove', 'skip']);
 export function buildPlan(
   metadata: PlanMetadata,
   decisions: InteractiveDecisions,
+  nonImportableModified?: DriftedResource[],
 ): RemediationPlan {
   const planDecisions: PlanDecision[] = [];
   const resources: Record<string, DriftedResource> = {};
@@ -61,6 +62,19 @@ export function buildPlan(
       action: 'skip',
     });
     resources[r.logicalResourceId] = r;
+  }
+
+  if (nonImportableModified) {
+    for (const r of nonImportableModified) {
+      planDecisions.push({
+        logicalResourceId: r.logicalResourceId,
+        resourceType: r.resourceType,
+        driftStatus: r.stackResourceDriftStatus,
+        physicalResourceId: r.physicalResourceId,
+        action: 'report_only',
+      });
+      resources[r.logicalResourceId] = r;
+    }
   }
 
   return {
@@ -176,6 +190,10 @@ export function planToDecisions(plan: RemediationPlan): {
         decisions.remove.push(resource);
         break;
       case 'skip':
+        decisions.skip.push(resource);
+        break;
+      case 'report_only':
+        // report_only resources are informational; treat as skip during execution
         decisions.skip.push(resource);
         break;
     }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -101,6 +101,18 @@ export interface RemediationOptions {
 }
 
 /**
+ * A drifted resource that cannot be imported via CloudFormation.
+ * MODIFIED resources are report-only; DELETED resources are auto-removed.
+ */
+export interface NonImportableResource {
+  logicalResourceId: string;
+  resourceType: string;
+  physicalResourceId: string;
+  driftStatus: 'MODIFIED' | 'DELETED';
+  propertyDifferences?: PropertyDifference[];
+}
+
+/**
  * Result of the remediation process
  */
 export interface RemediationResult {
@@ -112,6 +124,8 @@ export interface RemediationResult {
   skippedResources: string[];
   /** List of resource logical IDs permanently removed from the stack */
   removedResources: string[];
+  /** Non-importable drifted resources reported for manual action */
+  nonImportableResources: NonImportableResource[];
   /** Error messages if any */
   errors: string[];
 }
@@ -206,7 +220,7 @@ export interface PlanDecision {
   resourceType: string;
   driftStatus: 'MODIFIED' | 'DELETED';
   physicalResourceId: string;
-  action: 'autofix' | 'reimport' | 'remove' | 'skip';
+  action: 'autofix' | 'reimport' | 'remove' | 'skip' | 'report_only';
   /** Only present when action is 'reimport' */
   reimportPhysicalId?: string;
 }

--- a/test/integration/cdk-test-app/lib/drift-test-stack.ts
+++ b/test/integration/cdk-test-app/lib/drift-test-stack.ts
@@ -7,6 +7,7 @@ import * as targets from 'aws-cdk-lib/aws-events-targets';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as rds from 'aws-cdk-lib/aws-rds';
 import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 
 export class DriftTestStack extends cdk.Stack {
@@ -105,6 +106,19 @@ export class DriftTestStack extends cdk.Stack {
       enabled: true,
     });
     rule.addTarget(new targets.LambdaFunction(fn));
+
+    // SSM Parameters - NOT in eligible-resources.ts, used to test non-importable reporting
+    // MODIFIED test: break script changes this value
+    new ssm.StringParameter(this, 'DriftTestParam', {
+      parameterName: '/cfn-drift-test/config',
+      stringValue: 'original-value',
+    });
+
+    // DELETED test: break script deletes this parameter
+    new ssm.StringParameter(this, 'EphemeralParam', {
+      parameterName: '/cfn-drift-test/ephemeral',
+      stringValue: 'will-be-deleted',
+    });
 
     // Stack outputs for use by break/cleanup scripts
     new cdk.CfnOutput(this, 'DbInstanceIdentifier', {

--- a/test/integration/cdk-test-app/scripts/break-stack.sh
+++ b/test/integration/cdk-test-app/scripts/break-stack.sh
@@ -162,6 +162,25 @@ aws lambda update-function-configuration \
   --region "$REGION" \
   --profile "$PROFILE" > /dev/null
 
+# Step 7: Modify SSM Parameter value (creates MODIFIED drift on non-importable resource)
+echo ""
+echo "Step 7: Modifying SSM Parameter /cfn-drift-test/config"
+echo "  Changing value from 'original-value' to 'DRIFTED-value'"
+aws ssm put-parameter \
+  --name "/cfn-drift-test/config" \
+  --value "DRIFTED-value" \
+  --overwrite \
+  --region "$REGION" \
+  --profile "$PROFILE" > /dev/null
+
+# Step 8: Delete SSM Parameter (creates DELETED drift on non-importable resource)
+echo ""
+echo "Step 8: Deleting SSM Parameter /cfn-drift-test/ephemeral"
+aws ssm delete-parameter \
+  --name "/cfn-drift-test/ephemeral" \
+  --region "$REGION" \
+  --profile "$PROFILE"
+
 # Get replacement DB ARN
 NEW_DB_ARN=$(aws rds describe-db-instances \
   --db-instance-identifier "$NEW_DB_IDENTIFIER" \
@@ -179,6 +198,8 @@ echo "  2. MODIFIED: EC2 Instance tags ($EC2_INSTANCE_ID)"
 echo "  3. MODIFIED: S3 Bucket public access ($BUCKET_NAME)"
 echo "  4. MODIFIED: EventBridge Rule disabled ($RULE_NAME)"
 echo "  5. MODIFIED: Lambda timeout changed ($LAMBDA_NAME)"
+echo "  6. MODIFIED: SSM Parameter value changed (/cfn-drift-test/config) [non-importable]"
+echo "  7. DELETED: SSM Parameter deleted (/cfn-drift-test/ephemeral) [non-importable]"
 echo ""
 echo "Replacement DB:"
 echo "  Identifier: $NEW_DB_IDENTIFIER"
@@ -187,3 +208,5 @@ echo ""
 echo "When running remediation:"
 echo "  - For MODIFIED EC2/S3/Lambda/EventBridge: choose 'Autofix'"
 echo "  - For DELETED RDS: choose 'Re-import', enter: $NEW_DB_IDENTIFIER"
+echo "  - MODIFIED SSM Param: reported only (non-importable)"
+echo "  - DELETED SSM Param: auto-removed from template (non-importable)"

--- a/test/interactive.test.ts
+++ b/test/interactive.test.ts
@@ -22,7 +22,7 @@ jest.mock('@inquirer/prompts', () => ({
 }));
 
 import { select, input, confirm } from '@inquirer/prompts';
-import { displayCascadeWarning, formatDriftDiff, promptForDecisions } from '../src/lib/interactive';
+import { displayCascadeWarning, displayNonImportableReport, formatDriftDiff, promptForDecisions } from '../src/lib/interactive';
 import { DriftedResource, PropertyDifference } from '../src/lib/types';
 
 const mockSelect = select as jest.MockedFunction<typeof select>;
@@ -262,5 +262,82 @@ describe('displayCascadeWarning', () => {
     expect(output).toContain('temporarily removed from the stack');
     expect(output).toContain('SGIngress');
     expect(output).toContain('LambdaPerm');
+  });
+});
+
+describe('displayNonImportableReport', () => {
+  it('should not print anything when both lists are empty', () => {
+    displayNonImportableReport([], []);
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it('should display MODIFIED non-importable resources with property diffs', () => {
+    const modified: DriftedResource = {
+      logicalResourceId: 'SsmParam',
+      resourceType: 'AWS::SSM::Parameter',
+      physicalResourceId: '/cfn-drift-test/config',
+      stackResourceDriftStatus: 'MODIFIED',
+      propertyDifferences: [
+        {
+          propertyPath: '/Value',
+          expectedValue: '"original"',
+          actualValue: '"drifted"',
+          differenceType: 'NOT_EQUAL',
+        },
+      ],
+    };
+
+    displayNonImportableReport([modified], []);
+
+    const output = (console.log as jest.Mock).mock.calls.flat().join('\n');
+    expect(output).toContain('1 drifted resource(s) cannot be auto-remediated');
+    expect(output).toContain('MODIFIED (report only');
+    expect(output).toContain('SsmParam');
+    expect(output).toContain('AWS::SSM::Parameter');
+    expect(output).toContain('/cfn-drift-test/config');
+    expect(output).toContain('/Value');
+    expect(output).toContain('update your CDK/CloudFormation source');
+  });
+
+  it('should display DELETED non-importable resources', () => {
+    const deleted: DriftedResource = {
+      logicalResourceId: 'EphemeralParam',
+      resourceType: 'AWS::SSM::Parameter',
+      physicalResourceId: '/cfn-drift-test/ephemeral',
+      stackResourceDriftStatus: 'DELETED',
+    };
+
+    displayNonImportableReport([], [deleted]);
+
+    const output = (console.log as jest.Mock).mock.calls.flat().join('\n');
+    expect(output).toContain('1 drifted resource(s) cannot be auto-remediated');
+    expect(output).toContain('DELETED (will be removed from template');
+    expect(output).toContain('EphemeralParam');
+    expect(output).toContain('/cfn-drift-test/ephemeral');
+    expect(output).toContain('no longer exist in AWS');
+  });
+
+  it('should display both MODIFIED and DELETED sections', () => {
+    const modified: DriftedResource = {
+      logicalResourceId: 'SsmParam',
+      resourceType: 'AWS::SSM::Parameter',
+      physicalResourceId: '/cfn-drift-test/config',
+      stackResourceDriftStatus: 'MODIFIED',
+    };
+    const deleted: DriftedResource = {
+      logicalResourceId: 'EphemeralParam',
+      resourceType: 'AWS::SSM::Parameter',
+      physicalResourceId: '/cfn-drift-test/ephemeral',
+      stackResourceDriftStatus: 'DELETED',
+    };
+
+    displayNonImportableReport([modified], [deleted]);
+
+    const output = (console.log as jest.Mock).mock.calls.flat().join('\n');
+    expect(output).toContain('2 drifted resource(s) cannot be auto-remediated');
+    expect(output).toContain('MODIFIED (report only');
+    expect(output).toContain('DELETED (will be removed from template');
+    expect(output).toContain('SsmParam');
+    expect(output).toContain('EphemeralParam');
   });
 });

--- a/test/plan.test.ts
+++ b/test/plan.test.ts
@@ -80,6 +80,28 @@ describe('buildPlan', () => {
     expect(plan.decisions).toHaveLength(0);
     expect(Object.keys(plan._resources)).toHaveLength(0);
   });
+
+  it('creates report_only entries for nonImportableModified resources', () => {
+    const nonImportable = makeDriftedResource({
+      logicalResourceId: 'SsmParam',
+      resourceType: 'AWS::SSM::Parameter',
+    });
+    const decisions: InteractiveDecisions = {
+      autofix: [makeDriftedResource({ logicalResourceId: 'Bucket1' })],
+      reimport: [],
+      remove: [],
+      skip: [],
+    };
+
+    const plan = buildPlan(metadata, decisions, [nonImportable]);
+
+    expect(plan.decisions).toHaveLength(2);
+    const reportOnly = plan.decisions.find((d) => d.logicalResourceId === 'SsmParam');
+    expect(reportOnly).toBeDefined();
+    expect(reportOnly!.action).toBe('report_only');
+    expect(reportOnly!.resourceType).toBe('AWS::SSM::Parameter');
+    expect(plan._resources.SsmParam).toEqual(nonImportable);
+  });
 });
 
 describe('serializePlan', () => {
@@ -170,6 +192,13 @@ describe('loadPlan', () => {
     delete raw._resources;
     expect(() => loadPlan(JSON.stringify(raw), 'TestStack')).toThrow('missing _resources');
   });
+
+  it('accepts report_only as a valid action', () => {
+    const plan = validPlan();
+    const raw = JSON.parse(serializePlan(plan));
+    raw.decisions[0].action = 'report_only';
+    expect(() => loadPlan(JSON.stringify(raw), 'TestStack')).not.toThrow();
+  });
 });
 
 describe('planToDecisions', () => {
@@ -255,5 +284,26 @@ describe('planToDecisions', () => {
     expect(decisions.autofix).toHaveLength(0);
     expect(decisions.skip).toHaveLength(1);
     expect(decisions.skip[0].logicalResourceId).toBe('A');
+  });
+
+  it('treats report_only as skip during execution', () => {
+    const nonImportable = makeDriftedResource({
+      logicalResourceId: 'SsmParam',
+      resourceType: 'AWS::SSM::Parameter',
+    });
+    const decisions: InteractiveDecisions = {
+      autofix: [makeDriftedResource({ logicalResourceId: 'Bucket1' })],
+      reimport: [],
+      remove: [],
+      skip: [],
+    };
+
+    const plan = buildPlan(metadata, decisions, [nonImportable]);
+    const result = planToDecisions(plan);
+
+    expect(result.decisions.autofix).toHaveLength(1);
+    expect(result.decisions.skip).toHaveLength(1);
+    expect(result.decisions.skip[0].logicalResourceId).toBe('SsmParam');
+    expect(result.allDriftedResources).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary

- Non-importable MODIFIED resources are now reported with property diffs and guidance instead of silently skipped
- Non-importable DELETED resources are auto-removed from the stack template (resource no longer exists in AWS)
- Adds `report_only` action type for plan export/import workflow
- Adds SSM Parameter resources to integration test stack for non-importable drift scenarios

## Test plan

- [x] Unit tests: 127 pass (`npx projen build`)
- [x] Live tested against CfnDriftTestStack with 7 drift scenarios (5 importable + 2 non-importable SSM Parameters)
- [x] Dry-run output shows non-importable report with property diffs
- [x] Full remediation correctly remediates importable resources and reports non-importable ones
- [x] Post-remediation drift check confirms only the intentionally-skipped MODIFIED SSM Parameter remains drifted
- [ ] Interactive prompt flow (manual test planned)