### PR TITLE
ci: mute github-actions Dependabot version-update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,15 +25,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     labels:
       - dependencies
       - github-actions
-    cooldown:
-      default-days: 7
-      include:
-        - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - version-update:semver-major

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -123,25 +123,26 @@ project.gitignore?.addPatterns(
 project.npmignore?.addPatterns('.cfn-drift-remediate-backup-*');
 
 // Dependabot — lockfile-only, patch+minor only, cooldown before PRs open.
-// Patches the raw config because projen's Dependabot API doesn't yet expose
-// cooldown, ignore.update-types, or multi-ecosystem entries.
+// cooldown is natively supported as of projen 0.99.52 (PR #4650, 2026-04-10).
+// Still need raw config mutation for:
+//   - ignore.update-types (projen's DependabotIgnore type only has dependencyName + versions)
+//   - github-actions ecosystem (projen's Dependabot class only manages npm)
 const dependabot = new Dependabot(project.github!, {
   scheduleInterval: DependabotScheduleInterval.WEEKLY,
   versioningStrategy: VersioningStrategy.LOCKFILE_ONLY,
   labels: ['dependencies'],
   openPullRequestsLimit: 10,
+  cooldown: {
+    defaultDays: 7,
+    semverMinorDays: 7,
+    semverPatchDays: 3,
+    include: ['*'],
+  },
 });
 
-const npmUpdate = dependabot.config.updates[0];
-npmUpdate.cooldown = {
-  'default-days': 7,
-  'semver-minor-days': 7,
-  'semver-patch-days': 3,
-  'include': ['*'],
-};
-// Replace projen's lazy-resolved ignore with a static array.
-// Keeps the projen ignore (anti-tamper boundary) and blocks major bumps globally.
-npmUpdate.ignore = [
+// Override the rendered ignore to add an update-types rule blocking majors.
+// Keeps the projen ignore (anti-tamper boundary) that projen auto-adds via ignoreProjen.
+dependabot.config.updates[0].ignore = [
   { 'dependency-name': 'projen' },
   { 'dependency-name': '*', 'update-types': ['version-update:semver-major'] },
 ];

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -146,19 +146,19 @@ npmUpdate.ignore = [
   { 'dependency-name': '*', 'update-types': ['version-update:semver-major'] },
 ];
 
+// github-actions ecosystem is kept enabled for SECURITY ALERTS ONLY.
+// Version-update PRs are disabled (open-pull-requests-limit: 0) because
+// Dependabot would have to edit projen-generated workflow files directly,
+// which trips projen's anti-tamper check (the files get regenerated on
+// synth from .projenrc.ts). Empirically confirmed via PR #19 on this repo.
+// To bump action versions, use project.github.actions.set() in .projenrc.ts
+// or wait for a projen release that bumps its internal defaults.
 dependabot.config.updates.push({
   'package-ecosystem': 'github-actions',
   'directory': '/',
   'schedule': { interval: 'weekly' },
-  'open-pull-requests-limit': 5,
+  'open-pull-requests-limit': 0,
   'labels': ['dependencies', 'github-actions'],
-  'cooldown': {
-    'default-days': 7,
-    'include': ['*'],
-  },
-  'ignore': [
-    { 'dependency-name': '*', 'update-types': ['version-update:semver-major'] },
-  ],
 });
 
 // Security gate on PRs — calls the reusable osv-scanner workflow from


### PR DESCRIPTION
## Summary

Follow-up to #18 after empirical confirmation that the github-actions Dependabot ecosystem conflicts with projen's workflow file ownership.

## The finding

PR #19 (actions/setup-node 6 → 6.3.0) failed on build with a projen anti-tamper mutation diff on both \`build.yml\` and \`release.yml\`. Dependabot has to edit workflow files directly (there is no lockfile-only mode for github-actions), but those files are projen-generated. Anti-tamper correctly reverts the changes on synth.

Meanwhile PR #20 (@inquirer/prompts lockfile-only bump) passed all checks including build and security — confirming that the **npm + lockfile-only** pattern is clean.

## Updated boundary map

| Ecosystem | Modifies | Anti-tamper | Verdict |
|---|---|---|---|
| npm + lockfile-only | yarn.lock only | passes | works |
| github-actions | workflow YAML | fails | **alerts-only** |

## Changes

- \`.github/dependabot.yml\` github-actions entry: \`open-pull-requests-limit: 0\`
- Removed now-moot \`cooldown\` and \`ignore\` blocks from that entry
- In-code comment explaining why and pointing to \`project.github.actions.set()\` for manual bumps

Security alerts still fire (vulnerability detection is independent of version-update PRs).

## Next actions

- Close #19 with \`@dependabot close\` (it can never merge as-is)
- #20 can merge normally to validate the happy-path end-to-end