### PR TITLE
ci: spike Aikido Safe-Chain in-flight malware scanner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Install Aikido Safe-Chain (in-flight malware scanner)
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
         run: |-
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Install Aikido Safe-Chain (in-flight malware scanner)
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -35,6 +35,24 @@ const project = new typescript.TypeScriptProject({
     mutableBuild: false,
   },
 
+  // Aikido Safe-Chain — in-flight malware scanner that proxies all package
+  // manager commands (yarn/npm/pnpm/pip/etc.) through Aikido Intel.
+  // Blocks malicious packages BEFORE they hit disk, BEFORE install scripts run.
+  // Tokenless, free, with built-in 48h cooldown on freshly-published versions.
+  //
+  // workflowBootstrapSteps injects this BEFORE setup-node. The install script
+  // is OS-detection bash (no Node dependency) and adds shims to GITHUB_PATH;
+  // setup-node populates real yarn afterward. Empirically validate ordering
+  // works on first CI run — if shim resolution recurses, switch to a file
+  // override placing this between setup-node and yarn install.
+  workflowBootstrapSteps: [
+    {
+      name: 'Install Aikido Safe-Chain (in-flight malware scanner)',
+      run: 'curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci',
+    },
+  ],
+
+
   // GitHub Options
   githubOptions: {
     projenCredentials: GithubCredentials.fromApp({


### PR DESCRIPTION
## Summary

Spike to test whether Aikido Safe-Chain closes the parallel-execution gap exposed in PR #18: build runs \`yarn install\` (which executes install scripts) in parallel with osv-scanner, so a malicious install script can execute regardless of scan verdict.

Safe-Chain solves this by **intercepting the install itself** — a local proxy verifies packages against Aikido Intel before they hit disk.

## What changed

- \`workflowBootstrapSteps\` injects the Safe-Chain installer step before setup-node in **build.yml and release.yml**
- One step, one curl, no API key

## Properties of Safe-Chain (verified from upstream README)

- ✅ Tokenless, free, no API key
- ✅ Built-in 48h cooldown on freshly-published versions (their own supply-chain defense layer)
- ✅ Supports yarn / npm / pnpm / bun / pip / poetry / etc.
- ✅ Works on GitHub Actions, Azure Pipelines, CircleCI, Jenkins, GitLab, Bitbucket

## What this spike measures

| Question | Answer source |
|---|---|
| Does shim ordering work (safe-chain before setup-node)? | This PR's build run |
| Wall-clock cost of safe-chain install + proxy? | Compare build duration before/after |
| Any false positives on benign deps? | Build pass/fail |
| Behavior on Dependabot PRs (lockfile-only) — does shim play nice with --frozen-lockfile? | Future Dependabot PR after merge |

## Layered defense after this lands

1. **Aikido Safe-Chain** — in-flight real-time malware blocking + 48h cooldown
2. **Dependabot cooldown** — 7d default / 7d minor / 3d patch (from PR #18)
3. **osv-scanner** — known-CVE gate (CVSS ≥ 9.0 fails merge, from PR #18)
4. **projen anti-tamper** — package.json regenerated from .projenrc.ts (built-in)

## Known risk

Aikido issue [#118](https://github.com/AikidoSec/safe-chain/issues/118) reports "Not working in github actions / Error: The template is not valid" on some workflows. This PR's build run will tell us if cfn-drift-remediate hits it.

## Test plan

- [ ] Build passes (validates shim ordering + no false positives)
- [ ] Compare build duration to recent green builds (validates wall-clock cost)
- [ ] After merge, observe next Dependabot PR — does Safe-Chain shim handle \`yarn install --frozen-lockfile\` correctly?