### PR TITLE
chore: tighten Dependabot/Aikido config (groups + 7d cooldown)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,14 @@ updates:
           - version-update:semver-major
     labels:
       - dependencies
+    groups:
+      aws-sdk:
+        patterns:
+          - "@aws-sdk/*"
+          - "@smithy/*"
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Install Aikido Safe-Chain (in-flight malware scanner)
-        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+      - name: Install Aikido Safe-Chain (in-flight malware scanner, 7d minimum age)
+        run: |-
+          echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168" >> $GITHUB_ENV
+          curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,10 @@ jobs:
         run: |-
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      - name: Install Aikido Safe-Chain (in-flight malware scanner)
-        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+      - name: Install Aikido Safe-Chain (in-flight malware scanner, 7d minimum age)
+        run: |-
+          echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168" >> $GITHUB_ENV
+          curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -156,6 +156,18 @@ const dependabot = new Dependabot(project.github!, {
     semverPatchDays: 3,
     include: ['*'],
   },
+  // Group peer-coupled package families into single PRs. Without grouping,
+  // Dependabot opens N parallel PRs that fail build because nested peer-deps
+  // (@smithy/core, @typescript-eslint/utils) only resolve cleanly when the
+  // whole family moves together.
+  groups: {
+    'aws-sdk': {
+      patterns: ['@aws-sdk/*', '@smithy/*'],
+    },
+    'typescript-eslint': {
+      patterns: ['@typescript-eslint/*'],
+    },
+  },
 });
 
 // Override the rendered ignore to add an update-types rule blocking majors.

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -38,17 +38,26 @@ const project = new typescript.TypeScriptProject({
   // Aikido Safe-Chain — in-flight malware scanner that proxies all package
   // manager commands (yarn/npm/pnpm/pip/etc.) through Aikido Intel.
   // Blocks malicious packages BEFORE they hit disk, BEFORE install scripts run.
-  // Tokenless, free, with built-in 48h cooldown on freshly-published versions.
+  // Tokenless, free.
+  //
+  // SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168 raises the proxy-level cooldown
+  // from the 48h default to 7 days. Critically, this applies to ALL packages
+  // fetched (direct AND transitive), which closes the dependabot-core#14683
+  // gap where Dependabot's manifest-level cooldown does not see transitives.
+  // Empirically validated 2026-04-28 on PR #25: a transitive @typescript-eslint
+  // /types@8.59.1 published <48h prior was blocked here while passing
+  // Dependabot's 7-day patch cooldown on the direct dep.
   //
   // workflowBootstrapSteps injects this BEFORE setup-node. The install script
-  // is OS-detection bash (no Node dependency) and adds shims to GITHUB_PATH;
-  // setup-node populates real yarn afterward. Empirically validate ordering
-  // works on first CI run — if shim resolution recurses, switch to a file
-  // override placing this between setup-node and yarn install.
+  // is OS-detection bash (no Node dependency); setup-node populates real yarn
+  // afterward. Env var written via $GITHUB_ENV so subsequent install steps see it.
   workflowBootstrapSteps: [
     {
-      name: 'Install Aikido Safe-Chain (in-flight malware scanner)',
-      run: 'curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci',
+      name: 'Install Aikido Safe-Chain (in-flight malware scanner, 7d minimum age)',
+      run: [
+        'echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168" >> $GITHUB_ENV',
+        'curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci',
+      ].join('\n'),
     },
   ],
 


### PR DESCRIPTION
## Summary

Two related tightening changes to the Dependabot/Aikido stack:

### 1. Dependabot \`groups:\` for peer-coupled package families

| Group | Patterns | Why |
|---|---|---|
| \`aws-sdk\` | \`@aws-sdk/*\`, \`@smithy/*\` | All AWS SDK clients share nested \`@smithy/core\`. Bumping one alone produces TS 2308 duplicate-export errors. |
| \`typescript-eslint\` | \`@typescript-eslint/*\` | Parser and plugin share \`@typescript-eslint/utils\`. Out-of-step versions cause type mismatches. |

### 2. Aikido cooldown raised from 48h → 168h (7 days)

Sets \`SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168\` via \`$GITHUB_ENV\` so the proxy-level cooldown matches Dependabot's 7-day default.

**This is strictly stronger than Dependabot cooldown alone** because Aikido's check runs at the registry-proxy layer — it sees every tarball fetch, including transitives. Dependabot's manifest-level cooldown only sees direct bumps and misses transitives entirely (dependabot-core#14683).

## Empirical evidence (today, PR #25)

\`@typescript-eslint/parser@8.59.0\` bump cleared Dependabot's 3d patch cooldown on the direct dep. But a transitive \`@typescript-eslint/types@8.59.1\` was published <48h prior and Aikido blocked it at the proxy. Build failed, auto-merge held. The 14683 bug is real and we have it on tape.

## Operational impact

Before: 5 separate \`@aws-sdk/client-*\` PRs (#24, #26, #27, #28, #29) currently open, each unable to pass build alone.

After: each ecosystem refresh produces ONE grouped PR per family. Aikido cooldown raised to 7d means more PRs will be temporarily blocked when transitives are fresh — strictest layer wins, by design.

## Cleanup after merge

Close the 5 stale \`@aws-sdk/client-*\` PRs with \`@dependabot close\`. Dependabot will re-emit them as a single grouped PR on its next check.