### PR TITLE
ci: only rebase Aikido-cooldown stuck PRs, not real breakage

### DIFF
--- a/.github/workflows/dependabot-rebase-stuck.yml
+++ b/.github/workflows/dependabot-rebase-stuck.yml
@@ -7,16 +7,18 @@ on:
   workflow_dispatch: {}
 permissions:
   pull-requests: write
+  actions: read
 jobs:
   rebase:
     runs-on: ubuntu-latest
     steps:
-      - name: Comment @dependabot rebase on stuck Dependabot PRs
+      - name: Rebase Dependabot PRs blocked by Aikido cooldown
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |-
           set -euo pipefail
+
           stuck=$(gh pr list --repo "$REPO" \
             --author "app/dependabot" \
             --state open \
@@ -29,6 +31,23 @@ jobs:
           fi
 
           for pr in $stuck; do
-            echo "Rebasing PR #$pr (build failed; likely Aikido cooldown — refreshing)"
-            gh pr comment "$pr" --repo "$REPO" --body "@dependabot rebase"
+            run_id=$(gh pr view "$pr" --repo "$REPO" --json statusCheckRollup \
+              --jq '.statusCheckRollup[] | select(.name == "build") | .detailsUrl' \
+              | grep -oE "/runs/[0-9]+" | head -1 | cut -d/ -f3)
+
+            if [ -z "$run_id" ]; then
+              echo "PR #$pr: no build run id, skipping"
+              continue
+            fi
+
+            log=$(gh run view "$run_id" --repo "$REPO" --log-failed 2>&1 || true)
+
+            if echo "$log" | grep -q "minimum package age"; then
+              echo "PR #$pr: Aikido cooldown block — rebasing"
+              gh pr comment "$pr" --repo "$REPO" --body "@dependabot rebase"
+            elif echo "$log" | grep -q "Safe-chain: blocked"; then
+              echo "PR #$pr: Aikido blocked (non-age, possibly malware) — leaving for human review"
+            else
+              echo "PR #$pr: build failed for unrecognized reason — leaving for human review"
+            fi
           done

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -276,14 +276,15 @@ new YamlFile(project, '.github/workflows/dependabot-automerge.yml', {
 // since the required `build` check is in FAILURE state, GitHub never retries
 // on its own. The PR sits stuck even after Aikido's timer clears.
 //
-// This workflow runs daily and comments `@dependabot rebase` on any open
-// Dependabot PR with a failed `build` check. Rebase forces a fresh SHA so
-// all checks re-run, and also brings the PR up-to-date with main (which
-// strict branch protection requires anyway). Idempotent: if there's
-// genuinely no rebase to do, Dependabot is a no-op.
+// This workflow runs daily, finds Dependabot PRs with a failed `build`,
+// inspects the failure log, and rebases ONLY when the cause is Aikido's
+// "minimum package age" check (recoverable). Other failure modes — real
+// breakage, malware blocks, unrecognized errors — are explicitly left
+// alone so they remain visible to humans for review.
 //
-// V2 candidate: parse build log for "Safe-chain: blocked" before rebasing,
-// to avoid looping on PRs with genuine breakage.
+// Recovery loop on Aikido cooldown: rebase -> Dependabot pushes fresh SHA
+// -> build re-runs -> if Aikido timer cleared the build passes and
+// auto-merge fires; otherwise next day's run tries again.
 new YamlFile(project, '.github/workflows/dependabot-rebase-stuck.yml', {
   obj: {
     name: 'dependabot-rebase-stuck',
@@ -295,19 +296,21 @@ new YamlFile(project, '.github/workflows/dependabot-rebase-stuck.yml', {
     },
     permissions: {
       'pull-requests': 'write',
+      'actions': 'read',
     },
     jobs: {
       rebase: {
         'runs-on': 'ubuntu-latest',
         'steps': [
           {
-            name: 'Comment @dependabot rebase on stuck Dependabot PRs',
+            name: 'Rebase Dependabot PRs blocked by Aikido cooldown',
             env: {
               GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}',
               REPO: '${{ github.repository }}',
             },
             run: [
               'set -euo pipefail',
+              '',
               'stuck=$(gh pr list --repo "$REPO" \\',
               '  --author "app/dependabot" \\',
               '  --state open \\',
@@ -320,8 +323,25 @@ new YamlFile(project, '.github/workflows/dependabot-rebase-stuck.yml', {
               'fi',
               '',
               'for pr in $stuck; do',
-              '  echo "Rebasing PR #$pr (build failed; likely Aikido cooldown — refreshing)"',
-              '  gh pr comment "$pr" --repo "$REPO" --body "@dependabot rebase"',
+              '  run_id=$(gh pr view "$pr" --repo "$REPO" --json statusCheckRollup \\',
+              '    --jq \'.statusCheckRollup[] | select(.name == "build") | .detailsUrl\' \\',
+              '    | grep -oE "/runs/[0-9]+" | head -1 | cut -d/ -f3)',
+              '',
+              '  if [ -z "$run_id" ]; then',
+              '    echo "PR #$pr: no build run id, skipping"',
+              '    continue',
+              '  fi',
+              '',
+              '  log=$(gh run view "$run_id" --repo "$REPO" --log-failed 2>&1 || true)',
+              '',
+              '  if echo "$log" | grep -q "minimum package age"; then',
+              '    echo "PR #$pr: Aikido cooldown block — rebasing"',
+              '    gh pr comment "$pr" --repo "$REPO" --body "@dependabot rebase"',
+              '  elif echo "$log" | grep -q "Safe-chain: blocked"; then',
+              '    echo "PR #$pr: Aikido blocked (non-age, possibly malware) — leaving for human review"',
+              '  else',
+              '    echo "PR #$pr: build failed for unrecognized reason — leaving for human review"',
+              '  fi',
               'done',
             ].join('\n'),
           },


### PR DESCRIPTION
## Summary

V2 of \`dependabot-rebase-stuck\`. Before: rebased any Dependabot PR with a failed \`build\` check. After: only rebases when the failure log matches \`"minimum package age"\` (Aikido's recoverable cooldown signal).

## Test candidates available right now

After PR #31 (groups) merged, two grouped Dependabot PRs are currently stuck:

| PR | Group | Failure cause |
|---|---|---|
| #39 | aws-sdk (5 packages) | \`Safe-chain: blocked 8 ... minimum package age\` |
| #40 | typescript-eslint (2 packages) | \`Safe-chain: blocked 2 ... minimum package age\` |

Both are recoverable Aikido blocks — confirmed by inspecting the build logs before this PR was opened. After this lands, manual \`workflow_dispatch\` should:
1. Find both as stuck (build = FAILURE)
2. Identify both as \`minimum package age\` blocks
3. Comment \`@dependabot rebase\` on both
4. Skip nothing (we have no real-breakage candidates today)

## What's NOT rebased after this PR

- \`Safe-chain: blocked\` without \`minimum package age\` (likely malware) — needs human review
- Any other failure — real breakage, type errors, lint, etc. — needs human review

End state: any open Dependabot PR with a failed \`build\` is GUARANTEED to be one that needs human attention. The auto-recovery loop handles everything else silently.

## Permissions

Added \`actions: read\` to the workflow's GITHUB_TOKEN so it can fetch run logs via \`gh run view --log-failed\`.

## Test plan

- [ ] Merge this PR
- [ ] Manually fire \`dependabot-rebase-stuck\` via workflow_dispatch
- [ ] Confirm: log shows both #39 and #40 identified as Aikido cooldown, both rebased
- [ ] Wait ~5 days for Aikido's 7-day timer to clear on the affected transitives
- [ ] Confirm: next workflow run finds them passing build, auto-merge fires, both auto-merge