### PR TITLE
ci: pin Aikido Safe-Chain to 1.5.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Install Aikido Safe-Chain (in-flight malware scanner, 7d minimum age)
+      - name: Install Aikido Safe-Chain 1.5.3 (in-flight malware scanner, 7d minimum age)
         run: |-
           echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168" >> $GITHUB_ENV
-          curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+          curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh | sh -s -- --ci
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
         run: |-
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      - name: Install Aikido Safe-Chain (in-flight malware scanner, 7d minimum age)
+      - name: Install Aikido Safe-Chain 1.5.3 (in-flight malware scanner, 7d minimum age)
         run: |-
           echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168" >> $GITHUB_ENV
-          curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+          curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh | sh -s -- --ci
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -51,12 +51,17 @@ const project = new typescript.TypeScriptProject({
   // workflowBootstrapSteps injects this BEFORE setup-node. The install script
   // is OS-detection bash (no Node dependency); setup-node populates real yarn
   // afterward. Env var written via $GITHUB_ENV so subsequent install steps see it.
+  //
+  // Pinned to 1.5.3 (published 2026-05-12) — `releases/latest` would let
+  // an AikidoSec compromise (or accidental release) trigger an unreviewed
+  // rollout into every build. Bump via .projenrc.ts edit after reviewing
+  // the upstream changelog.
   workflowBootstrapSteps: [
     {
-      name: 'Install Aikido Safe-Chain (in-flight malware scanner, 7d minimum age)',
+      name: 'Install Aikido Safe-Chain 1.5.3 (in-flight malware scanner, 7d minimum age)',
       run: [
         'echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168" >> $GITHUB_ENV',
-        'curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci',
+        'curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh | sh -s -- --ci',
       ].join('\n'),
     },
   ],


### PR DESCRIPTION
## Summary
- Pin Safechain installer from `releases/latest` → `releases/download/1.5.3/install-safe-chain.sh`
- Bumps are now an explicit `.projenrc.ts` edit after reviewing upstream changelog

## Why
`releases/latest` means any AikidoSec compromise (or accidental release) rolls into every build with no review — exactly the supply-chain class Safechain itself exists to mitigate. Removes the implicit trust-by-recency.

## Test plan
- [ ] Build workflow runs green against this PR
- [ ] `grep -r "releases/latest" .github/` returns empty
- [ ] Generated workflow runs the pinned URL (visible in build logs)