### PR TITLE
ci: SHA-pin third-party actions in pull_request_target workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Install Aikido Safe-Chain (in-flight malware scanner, 7d minimum age)
+      - name: Install Aikido Safe-Chain 1.5.3 (in-flight malware scanner, 7d minimum age)
         run: |-
           echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168" >> $GITHUB_ENV
-          curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+          curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh | sh -s -- --ci
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Get Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge for safe Dependabot PRs

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
         run: |-
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      - name: Install Aikido Safe-Chain (in-flight malware scanner, 7d minimum age)
+      - name: Install Aikido Safe-Chain 1.5.3 (in-flight malware scanner, 7d minimum age)
         run: |-
           echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168" >> $GITHUB_ENV
-          curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+          curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh | sh -s -- --ci
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -134,6 +134,18 @@ releaseWorkflow.file!.addOverride('jobs.release_npm.steps.0.with.node-version', 
 // Set registry-url so setup-node configures .npmrc for OIDC token exchange
 releaseWorkflow.file!.addOverride('jobs.release_npm.steps.0.with.registry-url', 'https://registry.npmjs.org');
 
+// SHA-pin third-party actions used in pull_request_target contexts. A tag
+// reference (@v6) can be force-pushed if the upstream repo is compromised,
+// and the workflow would inherit elevated GITHUB_TOKEN scoped to PRs. SHA
+// pinning makes that swap visible in a diff. First-party actions/* and
+// github/* are left as version tags (lower-risk; GitHub-owned).
+const prLintWorkflow = project.github!.tryFindWorkflow('pull-request-lint')!;
+// amannn/action-semantic-pull-request v6.1.1
+prLintWorkflow.file!.addOverride(
+  'jobs.validate.steps.0.uses',
+  'amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50',
+);
+
 // .tool-versions file for asdf
 new TextFile(project, '.tool-versions', {
   lines: [
@@ -255,7 +267,8 @@ new YamlFile(project, '.github/workflows/dependabot-automerge.yml', {
           {
             name: 'Get Dependabot metadata',
             id: 'metadata',
-            uses: 'dependabot/fetch-metadata@v2',
+            // SHA-pinned (v2.5.0). See the prLintWorkflow override above for rationale.
+            uses: 'dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a',
             with: {
               'github-token': '${{ secrets.GITHUB_TOKEN }}',
             },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -51,12 +51,17 @@ const project = new typescript.TypeScriptProject({
   // workflowBootstrapSteps injects this BEFORE setup-node. The install script
   // is OS-detection bash (no Node dependency); setup-node populates real yarn
   // afterward. Env var written via $GITHUB_ENV so subsequent install steps see it.
+  //
+  // Pinned to 1.5.3 (published 2026-05-12) — `releases/latest` would let
+  // an AikidoSec compromise (or accidental release) trigger an unreviewed
+  // rollout into every build. Bump via .projenrc.ts edit after reviewing
+  // the upstream changelog.
   workflowBootstrapSteps: [
     {
-      name: 'Install Aikido Safe-Chain (in-flight malware scanner, 7d minimum age)',
+      name: 'Install Aikido Safe-Chain 1.5.3 (in-flight malware scanner, 7d minimum age)',
       run: [
         'echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168" >> $GITHUB_ENV',
-        'curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci',
+        'curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh | sh -s -- --ci',
       ].join('\n'),
     },
   ],


### PR DESCRIPTION
## Summary
- `amannn/action-semantic-pull-request@v6` → SHA `48f256284bd46cdaab1048c3721360e808335d50` (v6.1.1)
- `dependabot/fetch-metadata@v2` → SHA `21025c705c08248db411dc16f3619e6b5f9ea21a` (v2.5.0)
- First-party `actions/*` and `github/*` left as version tags

## Why
Both run in `pull_request_target` context with an elevated `GITHUB_TOKEN`. A force-pushed tag or upstream compromise would inherit that token with no diff to review. SHA pinning forces the substitution to show up as a code change.

## Stack
Stacked on #51 (Safechain pin). Will retarget to `main` automatically when #51 merges.

## Test plan
- [ ] PR lint check runs green
- [ ] `grep -E "uses: (amannn|dependabot/fetch-metadata|peter-evans)" .github/workflows/*.yml | grep -vE "@[a-f0-9]{40}"` returns empty