### PR TITLE
fix: neutralize string-typed broken refs in numeric properties (string ports)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@ import {
   setRetentionOnAllResources,
   transformTemplateForRemoval,
   analyzeCascadeRemovals,
+  coerceNumericPortProperties,
 } from './lib/template-transformer';
 import {
   RemediationOptions,
@@ -627,7 +628,7 @@ async function executeMutationSteps(
 
           await client.updateStack(
             stackInfo.stackId,
-            stringifyTemplate(phase1Template),
+            stringifyTemplate(coerceNumericPortProperties(phase1Template)),
             phase1Template.Parameters ? stackInfo.parameters : undefined,
             capabilities,
           );
@@ -641,6 +642,7 @@ async function executeMutationSteps(
         retainTemplate = template;
       }
 
+      retainTemplate = coerceNumericPortProperties(retainTemplate!);
       const retainedCount = Object.keys(retainTemplate!.Resources || {}).length;
       log(`DeletionPolicy: Retain set on ${retainedCount} resources. Proceeding...`);
 

--- a/src/lib/template-transformer.ts
+++ b/src/lib/template-transformer.ts
@@ -21,6 +21,12 @@ const CFN_PSEUDO_REFS = new Set([
  */
 const SUB_VARIABLE_PATTERN = /\$\{([^}]+)\}/g;
 
+const NUMERIC_GETATT_ATTRIBUTE = /(^|\.)Port$/i;
+
+function neutralizedRefValue(attributeName: string | undefined, placeholder: string): unknown {
+  return attributeName && NUMERIC_GETATT_ATTRIBUTE.test(attributeName) ? 0 : placeholder;
+}
+
 /**
  * Placeholder template used when all resources are removed
  */
@@ -364,6 +370,37 @@ export function setRetentionOnAllResources(template: CloudFormationTemplate): Cl
   return result;
 }
 
+const NUMERIC_PORT_PROPERTY = /^(From|To)?Port$/;
+
+/** Coerce integer-valued strings under port-like properties to numbers; modern CloudFormation handlers reject string ports (e.g. a resolved RDS Endpoint.Port string in FromPort). */
+export function coerceNumericPortProperties(template: CloudFormationTemplate): CloudFormationTemplate {
+  const result = deepClone(template);
+  coerceNumericPortsInValue(result.Resources);
+  return result;
+}
+
+function coerceNumericPortsInValue(value: unknown): void {
+  if (value === null || typeof value !== 'object') {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      coerceNumericPortsInValue(item);
+    }
+    return;
+  }
+
+  const obj = value as Record<string, unknown>;
+  for (const [key, val] of Object.entries(obj)) {
+    if (NUMERIC_PORT_PROPERTY.test(key) && typeof val === 'string' && /^-?\d+$/.test(val)) {
+      obj[key] = Number(val);
+    } else {
+      coerceNumericPortsInValue(val);
+    }
+  }
+}
+
 /**
  * Check if a value contains unresolved Ref/GetAtt/Fn::Sub references to specified logical IDs.
  * Used to detect broken references after resource removal.
@@ -450,10 +487,10 @@ export function neutralizeBrokenReferences(
   if ('Fn::GetAtt' in obj) {
     const getAtt = obj['Fn::GetAtt'];
     if (Array.isArray(getAtt) && getAtt.length >= 1 && removedLogicalIds.has(getAtt[0] as string)) {
-      return placeholder;
+      return neutralizedRefValue(getAtt[1] as string | undefined, placeholder);
     }
     if (typeof getAtt === 'string' && removedLogicalIds.has(getAtt.split('.')[0])) {
-      return placeholder;
+      return neutralizedRefValue(getAtt.split('.').slice(1).join('.'), placeholder);
     }
     return obj;
   }

--- a/test/template-transformer.test.ts
+++ b/test/template-transformer.test.ts
@@ -6,6 +6,8 @@ import {
   parseTemplate,
   stringifyTemplate,
   analyzeCascadeRemovals,
+  neutralizeBrokenReferences,
+  coerceNumericPortProperties,
 } from '../src/lib/template-transformer';
 import { CloudFormationTemplate } from '../src/lib/types';
 
@@ -584,5 +586,58 @@ describe('two-phase DELETED resource removal', () => {
     const result = transformTemplateForRemoval(retainTemplate, new Set(['DB']), new Map());
     expect(Object.keys(result.template.Resources)).not.toContain('SGIngress');
     expect(Object.keys(result.template.Resources)).not.toContain('Secret');
+  });
+});
+
+describe('numeric port neutralization and coercion', () => {
+  it('neutralizes a GetAtt to a removed Port attribute as a number, not the string placeholder', () => {
+    const removed = new Set(['DB']);
+    const arrayForm = neutralizeBrokenReferences(
+      { FromPort: { 'Fn::GetAtt': ['DB', 'Endpoint.Port'] } },
+      removed,
+    ) as Record<string, unknown>;
+    expect(arrayForm.FromPort).toBe(0);
+
+    const stringForm = neutralizeBrokenReferences(
+      { ToPort: { 'Fn::GetAtt': 'DB.Endpoint.Port' } },
+      removed,
+    ) as Record<string, unknown>;
+    expect(stringForm.ToPort).toBe(0);
+  });
+
+  it('keeps the string placeholder for non-numeric attributes', () => {
+    const result = neutralizeBrokenReferences(
+      { TargetId: { 'Fn::GetAtt': ['DB', 'Endpoint.Address'] } },
+      new Set(['DB']),
+    ) as Record<string, unknown>;
+    expect(result.TargetId).toBe('PLACEHOLDER');
+  });
+
+  it('coerces integer-valued string ports to numbers across the template', () => {
+    const template: CloudFormationTemplate = {
+      Resources: {
+        SGIngress: {
+          Type: 'AWS::EC2::SecurityGroupIngress',
+          Properties: { GroupId: 'sg-1', FromPort: '5432', ToPort: '5432', IpProtocol: 'tcp' },
+        },
+      },
+    };
+    const coerced = coerceNumericPortProperties(template);
+    expect(coerced.Resources.SGIngress.Properties!.FromPort).toBe(5432);
+    expect(coerced.Resources.SGIngress.Properties!.ToPort).toBe(5432);
+    expect(coerced.Resources.SGIngress.Properties!.IpProtocol).toBe('tcp');
+  });
+
+  it('leaves intrinsic-function port values untouched', () => {
+    const template: CloudFormationTemplate = {
+      Resources: {
+        SGIngress: {
+          Type: 'AWS::EC2::SecurityGroupIngress',
+          Properties: { FromPort: { Ref: 'PortParam' } },
+        },
+      },
+    };
+    const coerced = coerceNumericPortProperties(template);
+    expect(coerced.Resources.SGIngress.Properties!.FromPort).toEqual({ Ref: 'PortParam' });
   });
 });


### PR DESCRIPTION
## Problem

`cfn-drift-remediate` rolls back on stacks where a cascade-dependent resource references a DELETED resource through a **string-typed attribute used in a numeric property**. Canonical case:

```json
"FromPort": { "Fn::GetAtt": ["<deletedDb>", "Endpoint.Port"] }
```

RDS `Endpoint.Port` is a string-typed attribute, while `AWS::EC2::SecurityGroupIngress` `FromPort`/`ToPort` are integers. In **Step 6 Phase 1** (Set DeletionPolicy:Retain and remove DELETED resources), the broken ref is replaced with the string literal `'PLACEHOLDER'` — and CloudControl can't reliably read `SecurityGroupIngress` to recover the real port, so it falls to that placeholder. The Retain `updateStack` then fails:

```
Model validation failed (#/FromPort: expected type: Integer, found: String ...)
```

and the entire remediation rolls back. Hit against a real RDS stack: deleted primary DB + 19 SG-ingress rules referencing its `Endpoint.Port`.

## Fix

- `neutralizeBrokenReferences` emits a **numeric** placeholder (`0`) when the broken `GetAtt` targets a numeric attribute (`*.Port`), instead of the string `'PLACEHOLDER'`. Non-numeric attributes keep the string placeholder.
- New `coerceNumericPortProperties` pass converts integer-valued **string** ports to numbers (belt-and-suspenders for any other path that yields a string port, e.g. a successfully-resolved RDS `Endpoint.Port`). Runs before both Step-6 `updateStack` calls; leaves intrinsic-function values untouched.

## Tests

Added `numeric port neutralization and coercion`:
- GetAtt → `Endpoint.Port` neutralizes to `0` (array + string form)
- non-numeric attribute still neutralizes to `'PLACEHOLDER'`
- `coerceNumericPortProperties` coerces string ports, ignores non-port props and intrinsics

`npx projen build` green — 206 tests pass.